### PR TITLE
Add /services/users[/:uid] Page

### DIFF
--- a/src/services/redis-services/redis-services.service.ts
+++ b/src/services/redis-services/redis-services.service.ts
@@ -56,4 +56,16 @@ export class RedisServicesService {
 
     return parseInt(serviceId);
   }
+
+  async findUserServiceIds(uid: string): Promise<number[] | null> {
+    const services = await this.connectionService
+      .getRedis()
+      .smembers(`users.index.plugins.uid:${uid}`);
+
+    if (services == null) {
+      return null;
+    }
+
+    return services.map((s) => parseInt(s));
+  }
 }

--- a/src/services/services.controller.ts
+++ b/src/services/services.controller.ts
@@ -6,10 +6,13 @@ import {
   ParseBoolPipe,
   ParseIntPipe,
   Query,
+  Req,
 } from '@nestjs/common';
+import { Request } from 'express';
 import { Service } from './interfaces/service.interface';
 import { ServicesService } from './services.service';
 import { assertIsDefinedOrThrowNotFound } from '../assertions';
+import { AuthenticatedUser } from '../auth/authenticated-user.interface';
 
 @Controller('services')
 export class ServicesController {
@@ -34,6 +37,38 @@ export class ServicesController {
     );
     assertIsDefinedOrThrowNotFound(service);
     return service;
+  }
+
+  @Get('users')
+  async findUserServices(
+    @Req() request: Request,
+    @Query('includeCharts', new DefaultValuePipe(false), ParseBoolPipe)
+    includeCharts: boolean,
+  ): Promise<Service[]> {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    const user: AuthenticatedUser = request.user;
+    assertIsDefinedOrThrowNotFound(user);
+    const services = await this.servicesService.findUserServicesById(
+      user.uid,
+      includeCharts,
+    );
+    assertIsDefinedOrThrowNotFound(services);
+    return services;
+  }
+
+  @Get('users/:uid')
+  async findUserServicesById(
+    @Param('uid') uid: string,
+    @Query('includeCharts', new DefaultValuePipe(false), ParseBoolPipe)
+    includeCharts: boolean,
+  ): Promise<Service[]> {
+    const services = await this.servicesService.findUserServicesById(
+      uid,
+      includeCharts,
+    );
+    assertIsDefinedOrThrowNotFound(services);
+    return services;
   }
 
   @Get(':id')

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -67,4 +67,20 @@ export class ServicesService {
     }
     return this.findOne(serviceId, includeCharts);
   }
+
+  async findUserServicesById(
+    uid: string,
+    includeCharts = false,
+  ): Promise<Service[] | null> {
+    const serviceIds = await this.redisServicesService.findUserServiceIds(uid);
+
+    if (serviceIds === null) {
+      return null;
+    }
+
+    const services = await Promise.all(
+      serviceIds.map((id) => this.findOne(id, includeCharts)),
+    );
+    return services.filter(isNotNull);
+  }
 }


### PR DESCRIPTION
Two APIs have been added. It is used to obtain all services of users.
1. `/services/users/:uid`: Gets all services for the user with the specified `uid`
1. `/services/users`: The return is the same as above, but the `uid` is obtained by the user's login information. If not logged in, it returns `Not Found`

Signed-off-by: yuanlu <2573580691@qq.com>

Due to some mistakes, I have to re launch PR, and the content is consistent with the original pr( #8 )