### PR TITLE
fix: consider bukkitName for parsing server software brands, closes Bastian/bStats#92

### DIFF
--- a/src/data-submission/parser/bukkit-server-software.parser.spec.ts
+++ b/src/data-submission/parser/bukkit-server-software.parser.spec.ts
@@ -40,7 +40,7 @@ describe('bukkit-server-software.parser', () => {
         expected: 'Purpur',
       },
       {
-        name: 'Glowstone 1.18',
+        name: 'Glowstone 1.12.2',
         bukkitVersion: '2021.7.0-SNAPSHOT.09043bd (MC: 1.12.2)',
         bukkitName: 'Glowstone',
         expected: 'Glowstone',

--- a/src/data-submission/parser/bukkit-server-software.parser.spec.ts
+++ b/src/data-submission/parser/bukkit-server-software.parser.spec.ts
@@ -1,0 +1,101 @@
+import { BukkitServerSoftwareParser } from './bukkit-server-software.parser';
+
+describe('bukkit-server-software.parser', () => {
+  let parser: BukkitServerSoftwareParser;
+
+  beforeEach(() => {
+    parser = new BukkitServerSoftwareParser();
+  });
+
+  describe('parse', () => {
+    const testCases = [
+      {
+        name: 'Paper 1.21',
+        bukkitVersion: '1.21-38-1f5db50 (MC: 1.21)',
+        bukkitName: 'Paper',
+        expected: 'Paper',
+      },
+      {
+        name: 'Paper 1.20',
+        bukkitVersion: 'git-Paper-196 (MC: 1.20.1)',
+        bukkitName: 'Paper',
+        expected: 'Paper',
+      },
+      {
+        name: 'Spigot 1.21',
+        bukkitVersion: '4226-Spigot-146439e-2889b3a (MC: 1.21)',
+        bukkitName: 'CraftBukkit',
+        expected: 'Spigot',
+      },
+      {
+        name: 'Purpur 1.21',
+        bukkitVersion: '1.21-2250-797ce6b (MC: 1.21)',
+        bukkitName: 'Purpur',
+        expected: 'Purpur',
+      },
+      {
+        name: 'Purpur 1.20',
+        bukkitVersion: 'git-Purpur-2062 (MC: 1.20.1)',
+        bukkitName: 'Purpur',
+        expected: 'Purpur',
+      },
+      {
+        name: 'Glowstone 1.18',
+        bukkitVersion: '2021.7.0-SNAPSHOT.09043bd (MC: 1.12.2)',
+        bukkitName: 'Glowstone',
+        expected: 'Glowstone',
+      },
+      {
+        name: '"CraftBukkit" 1.21',
+        bukkitVersion: '4226-Bukkit-2889b3a (MC: 1.21)',
+        bukkitName: 'CraftBukkit',
+        expected: 'Bukkit',
+      },
+      {
+        name: 'CatServer 1.18',
+        bukkitVersion: '1.18.2-edda1229 (MC: 1.18.2)',
+        bukkitName: 'CatServer',
+        expected: 'CatServer',
+      },
+      {
+        name: 'Folia 1.20.6',
+        bukkitVersion: '1.20.6-5-d797082 (MC: 1.20.6)',
+        bukkitName: 'Folia',
+        expected: 'Folia',
+      },
+      {
+        name: 'Folia 1.20.1',
+        bukkitVersion: 'git-Folia-17 (MC: 1.20.1)',
+        bukkitName: 'Folia',
+        expected: 'Folia',
+      },
+      {
+        name: 'Arclight 1.21',
+        bukkitVersion: 'arclight-1.21-1.0.0-SNAPSHOT-b3349e9 (MC: 1.21)',
+        bukkitName: 'Arclight',
+        expected: 'Arclight',
+      },
+      {
+        name: 'TacoSpigot 1.9.4',
+        bukkitVersion: 'git-TacoSpigot-"af15657" (MC: 1.9.4)',
+        bukkitName: 'Paper',
+        expected: 'TacoSpigot',
+      },
+    ];
+
+    testCases.forEach((testCase) => {
+      it(`should return ${testCase.expected} for ${testCase.name}`, () => {
+        const result = parser.parse(
+          { idCustom: 'test' } as any,
+          {
+            bukkitVersion: testCase.bukkitVersion,
+            bukkitName: testCase.bukkitName,
+          } as any,
+          0,
+        );
+        expect(result).toHaveLength(1);
+        expect(result?.[0]?.data?.value).toBe(testCase.expected);
+      });
+    });
+  });
+});

--- a/src/data-submission/parser/bukkit-server-software.parser.ts
+++ b/src/data-submission/parser/bukkit-server-software.parser.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import {
   SubmitDataCustomChartDto,
   SubmitDataDto,
@@ -6,14 +6,36 @@ import {
 import { Parser } from './interfaces/parser.interface';
 import { DefaultChart } from '../../charts/interfaces/charts/default-chart.interface';
 
+const serverSoftwareBrands = new Map<string, string>();
+serverSoftwareBrands.set('bukkit', 'Bukkit');
+serverSoftwareBrands.set('taco', 'TacoSpigot');
+serverSoftwareBrands.set('paper', 'Paper');
+serverSoftwareBrands.set('folia', 'Folia');
+serverSoftwareBrands.set('spigot', 'Spigot');
+serverSoftwareBrands.set('catserver', 'CatServer');
+serverSoftwareBrands.set('lava', 'Lava');
+serverSoftwareBrands.set('mohist', 'Mohist');
+serverSoftwareBrands.set('tuinity', 'Tuinity');
+serverSoftwareBrands.set('purpur', 'Purpur');
+serverSoftwareBrands.set('airplane', 'Airplane');
+serverSoftwareBrands.set('yatopia', 'Yatopia');
+serverSoftwareBrands.set('arclight', 'Arclight');
+serverSoftwareBrands.set('magma', 'Magma');
+serverSoftwareBrands.set('titanium', 'Titanium');
+serverSoftwareBrands.set('scissors', 'Scissors');
+serverSoftwareBrands.set('gale', 'Gale');
+serverSoftwareBrands.set('glowstone', 'Glowstone');
+
 @Injectable()
 export class BukkitServerSoftwareParser implements Parser {
+  private readonly logger = new Logger(BukkitServerSoftwareParser.name);
+
   parse(
     chart: DefaultChart,
     submitDataDto: SubmitDataDto,
     requestRandom: number,
   ): SubmitDataCustomChartDto[] | null {
-    const { bukkitVersion } = submitDataDto;
+    const { bukkitVersion, bukkitName } = submitDataDto;
 
     if (typeof bukkitVersion !== 'string') {
       return null;
@@ -24,44 +46,35 @@ export class BukkitServerSoftwareParser implements Parser {
       return null;
     }
 
-    const lowercaseBukkitVersion = bukkitVersion.toLowerCase();
     let softwareName = 'Unknown';
 
-    // Maybe there's a good regex pattern, but sometimes the bukkitVersion looks pretty strange
-    if (lowercaseBukkitVersion.indexOf('bukkit') !== -1) {
-      softwareName = 'Bukkit';
-    } else if (lowercaseBukkitVersion.indexOf('taco') !== -1) {
-      softwareName = 'TacoSpigot';
-    } else if (lowercaseBukkitVersion.indexOf('paper') !== -1) {
-      softwareName = 'Paper';
-    } else if (lowercaseBukkitVersion.indexOf('folia') !== -1) {
-      softwareName = 'Folia';
-    } else if (lowercaseBukkitVersion.indexOf('spigot') !== -1) {
-      softwareName = 'Spigot';
-    } else if (lowercaseBukkitVersion.indexOf('catserver') !== -1) {
-      softwareName = 'CatServer';
-    } else if (lowercaseBukkitVersion.indexOf('lava') !== -1) {
-      softwareName = 'Lava';
-    } else if (lowercaseBukkitVersion.indexOf('mohist') !== -1) {
-      softwareName = 'Mohist';
-    } else if (lowercaseBukkitVersion.indexOf('tuinity') !== -1) {
-      softwareName = 'Tuinity';
-    } else if (lowercaseBukkitVersion.indexOf('purpur') !== -1) {
-      softwareName = 'Purpur';
-    } else if (lowercaseBukkitVersion.indexOf('airplane') !== -1) {
-      softwareName = 'Airplane';
-    } else if (lowercaseBukkitVersion.indexOf('yatopia') !== -1) {
-      softwareName = 'Yatopia';
-    } else if (lowercaseBukkitVersion.indexOf('arclight') !== -1) {
-      softwareName = 'Arclight';
-    } else if (lowercaseBukkitVersion.indexOf('magma') !== -1) {
-      softwareName = 'Magma';
-    } else if (lowercaseBukkitVersion.indexOf('titanium') !== -1) {
-      softwareName = 'Titanium';
-    } else if (lowercaseBukkitVersion.indexOf('scissors') !== -1) {
-      softwareName = 'Scissors';
-    } else if (lowercaseBukkitVersion.indexOf('gale') !== -1) {
-      softwareName = 'Gale';
+    // First try to find the software name based on the bukkit version
+    const lowercaseBukkitVersion = bukkitVersion.toLowerCase();
+    for (const [brand, name] of serverSoftwareBrands.entries()) {
+      if (lowercaseBukkitVersion.indexOf(brand) !== -1) {
+        softwareName = name;
+        break;
+      }
+    }
+
+    // then try to find the software name based on the bukkit name
+    if (softwareName === 'Unknown' && typeof bukkitName === 'string') {
+      const lowercaseBukkitName = bukkitName.toLowerCase();
+      const maybeSoftwareName = serverSoftwareBrands.get(lowercaseBukkitName);
+      if (maybeSoftwareName) {
+        softwareName = maybeSoftwareName;
+      }
+    }
+
+    // ultimately we log a message for further investigation
+    if (softwareName === 'Unknown') {
+      this.logger.log(
+        'Unknown server software: bukkitVersion="' +
+          bukkitVersion +
+          '", bukkitName="' +
+          bukkitName +
+          '"',
+      );
     }
 
     return [

--- a/test.http
+++ b/test.http
@@ -1,0 +1,445 @@
+### send paper
+POST http://localhost:3001/legacy/submitData/server-implementation
+Accept: application/json
+Content-Type: application/json
+User-Agent: MC-Server/1.0
+
+{
+  "serverUUID": "fe3969d1-e683-4f66-82bb-b96e283f5792",
+  "osVersion": "10.0",
+  "plugins": [
+    {
+      "pluginName": "Paper",
+      "customCharts": [
+        {
+          "chartId": "minecraft_version",
+          "data": {
+            "value": "1.21"
+          }
+        },
+        {
+          "chartId": "online_mode",
+          "data": {
+            "value": "online"
+          }
+        },
+        {
+          "chartId": "paper_version",
+          "data": {
+            "value": "unknown"
+          }
+        },
+        {
+          "chartId": "java_version",
+          "data": {
+            "values": {
+              "Java 21": {
+                "21.0.3": 1
+              }
+            }
+          }
+        },
+        {
+          "chartId": "legacy_plugins",
+          "data": {
+            "values": {
+              "0 ?": {
+                "0": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "osArch": "amd64",
+  "osName": "Windows 11",
+  "coreCount": 24
+}
+
+### send test plugin paper 1.21
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "1.21-38-1f5db50 (MC: 1.21)",
+  "bukkitName": "Paper",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "7386d410-f71e-447c-b356-ee809c7db098",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin paper 1.20
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "git-Paper-196 (MC: 1.20.1)",
+  "bukkitName": "Paper",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "0fde82f6-133c-4f06-b010-f9611d57fc98",
+  "metricsVersion": "3.0.2"
+}
+
+
+### send test plugin spigot 1.21
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "4226-Spigot-146439e-2889b3a (MC: 1.21)",
+  "bukkitName": "CraftBukkit",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "42f7545e-ddda-4177-92f1-ea6e5a5b608a",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin purpur 1.21
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "1.21-2250-797ce6b (MC: 1.21)",
+  "bukkitName": "Purpur",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "28349076-d5e0-4af2-9272-22f38a09c9be",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin purpur 1.20
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "git-Purpur-2062 (MC: 1.20.1)",
+  "bukkitName": "Purpur",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "28349076-d5e0-4af2-9272-22f38a09c9be",
+  "metricsVersion": "3.0.2"
+}
+
+
+### send test plugin glowstone 1.12
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "2021.7.0-SNAPSHOT.09043bd (MC: 1.12.2)",
+  "bukkitName": "Glowstone",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "0fde82f6-133c-4f06-b010-f9611d57fc98",
+  "metricsVersion": "3.0.2"
+}
+
+
+### send test plugin "craftbukkit" 1.21
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "4226-Bukkit-2889b3a (MC: 1.21)",
+  "bukkitName": "CraftBukkit",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "7386d410-f71e-447c-b356-ee809c7db098",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin catserver 1.18
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "1.18.2-edda1229 (MC: 1.18.2)",
+  "bukkitName": "CatServer",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "42f7545e-ddda-4177-92f1-ea6e5a5b608a",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin folia 1.20.6
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "1.20.6-5-d797082 (MC: 1.20.6)",
+  "bukkitName": "Folia",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "0fde82f6-133c-4f06-b010-f9611d57fc98",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin folia 1.20.1
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "git-Folia-17 (MC: 1.20.1)",
+  "bukkitName": "Folia",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "0fde82f6-133c-4f06-b010-f9611d57fc98",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin arclight 1.21
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "arclight-1.21-1.0.0-SNAPSHOT-b3349e9 (MC: 1.21)",
+  "bukkitName": "Arclight",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "7386d410-f71e-447c-b356-ee809c7db098",
+  "metricsVersion": "3.0.2"
+}
+
+### send test plugin tacospigot 1.9.4
+POST http://localhost:3001/data/bukkit
+Accept: application/json
+Content-Type: application/json
+User-Agent: Metrics-Service/1
+
+{
+  "playerAmount": 0,
+  "onlineMode": 1,
+  "bukkitVersion": "git-TacoSpigot-\"af15657\" (MC: 1.9.4)",
+  "bukkitName": "Paper",
+  "javaVersion": "21.0.2",
+  "osName": "Windows 11",
+  "osArch": "amd64",
+  "osVersion": "10.0",
+  "coreCount": 24,
+  "service": {
+    "pluginVersion": "1.0.0-SNAPSHOT",
+    "id": 1234,
+    "customCharts": [
+      {
+        "chartId": "chart_id",
+        "data": {
+          "value": "My value"
+        }
+      }
+    ]
+  },
+  "serverUUID": "42f7545e-ddda-4177-92f1-ea6e5a5b608a",
+  "metricsVersion": "3.0.2"
+}


### PR DESCRIPTION
this also cleans up the giant if-else tree and adds a test case

this should be a less invasive change than #16 (which failed my test cases)